### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server providing dynamic short-term and long-term memory management with Chinese language support.
 
+<a href="https://glama.ai/mcp/servers/@win10ogod/memory-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@win10ogod/memory-mcp-server/badge" alt="Memory Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server implements a sophisticated memory system extracted from the GentianAphrodite project, offering:
@@ -267,4 +271,3 @@ MIT
 ## Credits
 
 Extracted and generalized from the [GentianAphrodite](https://github.com/steve02081504/GentianAphrodite) project.
-


### PR DESCRIPTION
This PR adds a badge for the [Memory MCP Server](https://glama.ai/mcp/servers/@win10ogod/memory-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@win10ogod/memory-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@win10ogod/memory-mcp-server/badge" alt="Memory Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.