### PR TITLE
Improve memory tool robustness and add simulated client test

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Add a permanent memory with a trigger condition.
 - `name` (string): Unique memory name
 - `prompt` (string): Memory content
 - `trigger` (string): JavaScript code for activation condition
+- `conversation_id` (string, optional): Conversation ID to store the memory under (defaults to "default")
 - `createdContext` (string, optional): Context description
 - `recentMessages` (array, optional): Auto-generate context from messages
 
@@ -162,13 +163,21 @@ Update an existing long-term memory.
 - `name` (string): Memory name to update
 - `trigger` (string, optional): New trigger condition
 - `prompt` (string, optional): New content
+- `conversation_id` (string, optional): Conversation ID that owns the memory
 - `updatedContext` (string, optional): Update context
 
 #### `delete_long_term_memory`
 Delete a long-term memory by name.
 
+**Parameters:**
+- `name` (string): Memory name to delete
+- `conversation_id` (string, optional): Conversation ID that owns the memory
+
 #### `list_long_term_memories`
 List all long-term memories with basic info.
+
+**Parameters:**
+- `conversation_id` (string, optional): Conversation ID to inspect (defaults to "default")
 
 #### `search_long_term_memories`
 Search and activate memories based on current context.
@@ -182,6 +191,10 @@ Search and activate memories based on current context.
 
 #### `get_memory_context`
 Get creation and update context of a specific memory.
+
+**Parameters:**
+- `name` (string): Memory name to inspect
+- `conversation_id` (string, optional): Conversation ID that owns the memory
 
 ## Architecture
 

--- a/scripts/simulated-client.js
+++ b/scripts/simulated-client.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { createServer } from '../src/index.js';
+
+function parseToolResponse(response) {
+  assert.ok(response, 'Tool response should be defined');
+  if (response.isError) {
+    const message = response.content?.find(item => item.type === 'text')?.text || 'Unknown MCP error';
+    throw new Error(`Tool invocation failed: ${message}`);
+  }
+
+  const textItem = response.content?.find(item => item.type === 'text');
+  assert.ok(textItem, 'Tool response must include text content');
+
+  return JSON.parse(textItem.text);
+}
+
+async function cleanupConversationData(conversationId) {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const repoRoot = path.resolve(__dirname, '..');
+  const dataDir = path.join(repoRoot, 'data');
+  const sanitizedId = conversationId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  const targetDir = path.join(dataDir, sanitizedId);
+
+  await fs.rm(targetDir, { recursive: true, force: true });
+}
+
+async function main() {
+  const server = await createServer();
+  const listHandler = server._requestHandlers.get('tools/list');
+  const callHandler = server._requestHandlers.get('tools/call');
+
+  assert.ok(typeof listHandler === 'function', 'tools/list handler should be registered');
+  assert.ok(typeof callHandler === 'function', 'tools/call handler should be registered');
+
+  const listResponse = await listHandler({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/list',
+    params: {}
+  });
+
+  assert.ok(Array.isArray(listResponse.tools), 'tools/list should return an array');
+  assert.ok(listResponse.tools.length >= 1, 'tools/list should return registered tools');
+
+  const addToolSchema = listResponse.tools.find(tool => tool.name === 'add_long_term_memory');
+  assert.ok(addToolSchema, 'add_long_term_memory should be registered');
+  assert.equal(addToolSchema.inputSchema.type, 'object');
+  assert.ok(addToolSchema.inputSchema.properties?.conversation_id, 'add_long_term_memory schema should expose conversation_id');
+
+  const listToolSchema = listResponse.tools.find(tool => tool.name === 'list_long_term_memories');
+  assert.ok(listToolSchema?.inputSchema?.properties?.conversation_id, 'list_long_term_memories schema should expose conversation_id');
+
+  const conversationId = 'sim-client-e2e';
+  const memoryName = `simulated-memory-${Date.now()}`;
+
+  const addResult = await callHandler({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'add_long_term_memory',
+      arguments: {
+        conversation_id: conversationId,
+        name: memoryName,
+        prompt: 'Memory created during simulated MCP client test.',
+        trigger: 'true',
+        createdContext: 'Simulated MCP client run'
+      }
+    }
+  });
+
+  const addParsed = parseToolResponse(addResult);
+  assert.equal(addParsed.success, true, 'Long-term memory should be added successfully');
+
+  const scopedList = await callHandler({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: {
+      name: 'list_long_term_memories',
+      arguments: {
+        conversation_id: conversationId
+      }
+    }
+  });
+
+  const scopedListParsed = parseToolResponse(scopedList);
+  assert.ok(Array.isArray(scopedListParsed.memories), 'list_long_term_memories should return an array');
+  assert.ok(
+    scopedListParsed.memories.some(mem => mem.name === memoryName),
+    'Newly added memory should exist in scoped conversation'
+  );
+
+  const defaultList = await callHandler({
+    jsonrpc: '2.0',
+    id: 4,
+    method: 'tools/call',
+    params: {
+      name: 'list_long_term_memories',
+      arguments: {}
+    }
+  });
+
+  const defaultListParsed = parseToolResponse(defaultList);
+  const existsInDefault = (defaultListParsed.memories || []).some(mem => mem.name === memoryName);
+  assert.equal(existsInDefault, false, 'Scoped memory should not leak into default conversation');
+
+  const contextResult = await callHandler({
+    jsonrpc: '2.0',
+    id: 5,
+    method: 'tools/call',
+    params: {
+      name: 'get_memory_context',
+      arguments: {
+        conversation_id: conversationId,
+        name: memoryName
+      }
+    }
+  });
+
+  const contextParsed = parseToolResponse(contextResult);
+  assert.equal(contextParsed.success, true, 'get_memory_context should succeed for scoped memory');
+  assert.equal(contextParsed.name, memoryName, 'Context response should match memory name');
+
+  await cleanupConversationData(conversationId);
+
+  console.log('✅ Simulated MCP client test completed successfully');
+  process.exit(0);
+}
+
+main().catch(async (error) => {
+  console.error('❌ Simulated MCP client test failed:', error);
+  await cleanupConversationData('sim-client-e2e');
+  process.exit(1);
+});

--- a/src/tools/long-term-tools.js
+++ b/src/tools/long-term-tools.js
@@ -22,6 +22,7 @@ export function createLongTermTools(memoryManager, storageManager) {
         name: z.string().describe('Unique name for the memory'),
         prompt: z.string().describe('The memory content to be recalled when triggered'),
         trigger: z.string().describe('JavaScript code that returns true/false to determine if memory should activate. Example: "match_keys(context.messages, [\'birthday\'], \'any\') || new Date().getMonth() === 6"'),
+        conversation_id: z.string().optional().describe('Conversation ID that owns this memory (defaults to "default")'),
         createdContext: z.string().optional().describe('Optional context about when/why this memory was created'),
         recentMessages: z.array(z.object({
           role: z.enum(['user', 'assistant', 'system']),
@@ -72,6 +73,7 @@ export function createLongTermTools(memoryManager, storageManager) {
         name: z.string().describe('Name of the memory to update'),
         trigger: z.string().optional().describe('New trigger condition (JavaScript code)'),
         prompt: z.string().optional().describe('New memory content'),
+        conversation_id: z.string().optional().describe('Conversation ID that owns this memory'),
         updatedContext: z.string().optional().describe('Context about this update'),
         recentMessages: z.array(z.object({
           role: z.enum(['user', 'assistant', 'system']),
@@ -124,7 +126,8 @@ export function createLongTermTools(memoryManager, storageManager) {
       name: 'delete_long_term_memory',
       description: 'Delete a long-term memory by name.',
       inputSchema: z.object({
-        name: z.string().describe('Name of the memory to delete')
+        name: z.string().describe('Name of the memory to delete'),
+        conversation_id: z.string().optional().describe('Conversation ID that owns this memory')
       }),
       handler: async (args) => {
         try {
@@ -155,7 +158,9 @@ export function createLongTermTools(memoryManager, storageManager) {
     {
       name: 'list_long_term_memories',
       description: 'List all long-term memory names and their basic information.',
-      inputSchema: z.object({}),
+      inputSchema: z.object({
+        conversation_id: z.string().optional().describe('Conversation ID to inspect (defaults to "default")')
+      }),
       handler: async (args) => {
         try {
           const memories = memoryManager.getMemories();
@@ -223,7 +228,8 @@ export function createLongTermTools(memoryManager, storageManager) {
       name: 'get_memory_context',
       description: 'Get the creation and update context of a specific long-term memory.',
       inputSchema: z.object({
-        name: z.string().describe('Name of the memory')
+        name: z.string().describe('Name of the memory'),
+        conversation_id: z.string().optional().describe('Conversation ID that owns this memory')
       }),
       handler: async (args) => {
         try {

--- a/src/utils/zod-to-json-schema.js
+++ b/src/utils/zod-to-json-schema.js
@@ -1,0 +1,196 @@
+import { z } from 'zod';
+
+const { ZodFirstPartyTypeKind } = z;
+
+function applyMetadata(schema, zodType) {
+  if (zodType.description && !schema.description) {
+    schema.description = zodType.description;
+  }
+  if (typeof zodType._def?.defaultValue === 'function') {
+    try {
+      schema.default = zodType._def.defaultValue();
+    } catch (error) {
+      // ignore default evaluation errors
+    }
+  }
+  return schema;
+}
+
+function mergeTypeWithNull(typeSchema) {
+  if (!typeSchema) return typeSchema;
+  if ('anyOf' in typeSchema) {
+    typeSchema.anyOf = [...typeSchema.anyOf, { type: 'null' }];
+    return typeSchema;
+  }
+  if (typeSchema.type === undefined) {
+    typeSchema.type = ['null'];
+    return typeSchema;
+  }
+  if (Array.isArray(typeSchema.type)) {
+    if (!typeSchema.type.includes('null')) {
+      typeSchema.type = [...typeSchema.type, 'null'];
+    }
+  } else if (typeSchema.type !== 'null') {
+    typeSchema.type = [typeSchema.type, 'null'];
+  }
+  return typeSchema;
+}
+
+function unwrapEffects(schema) {
+  let current = schema;
+  while (current && current._def?.typeName === ZodFirstPartyTypeKind.ZodEffects) {
+    current = current._def.schema;
+  }
+  return current || schema;
+}
+
+export function zodToJsonSchema(zodType) {
+  if (!zodType || typeof zodType !== 'object') {
+    return {};
+  }
+
+  const normalized = unwrapEffects(zodType);
+  const def = normalized._def;
+
+  let schema;
+
+  switch (def.typeName) {
+    case ZodFirstPartyTypeKind.ZodString: {
+      schema = { type: 'string' };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodNumber: {
+      const isInt = def.checks?.some(check => check.kind === 'int');
+      schema = { type: isInt ? 'integer' : 'number' };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodBoolean: {
+      schema = { type: 'boolean' };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodLiteral: {
+      schema = { const: def.value };
+      const valueType = typeof def.value;
+      if (['string', 'number', 'boolean'].includes(valueType)) {
+        schema.type = valueType;
+      }
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodEnum: {
+      schema = { type: 'string', enum: [...def.values] };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodObject: {
+      const shape = def.shape();
+      const properties = {};
+      const required = [];
+
+      for (const [key, child] of Object.entries(shape)) {
+        const childSchema = zodToJsonSchema(child);
+        if (Object.keys(childSchema).length === 0) {
+          continue;
+        }
+        properties[key] = childSchema;
+        if (!child.isOptional()) {
+          required.push(key);
+        }
+      }
+
+      schema = {
+        type: 'object',
+        properties,
+      };
+
+      if (required.length > 0) {
+        schema.required = required;
+      }
+
+      if (def.catchall && def.catchall._def?.typeName !== ZodFirstPartyTypeKind.ZodNever) {
+        schema.additionalProperties = zodToJsonSchema(def.catchall);
+      } else if (def.unknownKeys === 'passthrough') {
+        schema.additionalProperties = true;
+      } else {
+        schema.additionalProperties = false;
+      }
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodArray: {
+      const itemSchema = zodToJsonSchema(def.type);
+      schema = {
+        type: 'array',
+        items: Object.keys(itemSchema).length > 0 ? itemSchema : {},
+      };
+      if (typeof def.minLength === 'number') {
+        schema.minItems = def.minLength;
+      }
+      if (typeof def.maxLength === 'number') {
+        schema.maxItems = def.maxLength;
+      }
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodUnion: {
+      schema = {
+        anyOf: def.options.map(option => zodToJsonSchema(option))
+      };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
+      schema = {
+        oneOf: def.options.map(option => zodToJsonSchema(option))
+      };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodOptional: {
+      schema = zodToJsonSchema(def.innerType);
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodNullable: {
+      schema = mergeTypeWithNull(zodToJsonSchema(def.innerType));
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodDefault: {
+      schema = zodToJsonSchema(def.innerType);
+      if (typeof def.defaultValue === 'function') {
+        try {
+          schema.default = def.defaultValue();
+        } catch (error) {
+          // ignore default evaluation errors
+        }
+      }
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodRecord: {
+      schema = {
+        type: 'object',
+        additionalProperties: zodToJsonSchema(def.valueType)
+      };
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodAny: {
+      schema = {};
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodUnknown: {
+      schema = {};
+      break;
+    }
+    case ZodFirstPartyTypeKind.ZodNever: {
+      schema = { not: {} };
+      break;
+    }
+    default: {
+      schema = {};
+      break;
+    }
+  }
+
+  if (!schema) {
+    schema = {};
+  }
+
+  applyMetadata(schema, normalized);
+
+  return schema;
+}
+
+export default zodToJsonSchema;


### PR DESCRIPTION
## Summary
- expose conversation_id parameters for long-term memory tools and documentation to ensure per-conversation storage
- harden short-term memory loading/calculations against malformed persisted data
- generate complete JSON schemas for tools, scope tool registrations, and add a simulated MCP client regression test script

## Testing
- node scripts/simulated-client.js
- node test-basic.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de02aa4ac8321b391786edd5153d2)